### PR TITLE
Fix Traefik backend transport and update Ionic production build

### DIFF
--- a/src/adaos/integrations/inimatic/deployment/docker-compose.yaml
+++ b/src/adaos/integrations/inimatic/deployment/docker-compose.yaml
@@ -50,7 +50,6 @@ services:
             - traefik.http.routers.traefik.service=api@internal
             - "traefik.http.middlewares.traefik-auth.basicauth.users=admin:$$2y$$05$$PTGvGW05DTIfUs7wA4vt7.SqRaH4zTK.VM1sBXU.I0ojnr/Iyvd2S"
             - traefik.http.routers.traefik.middlewares=traefik-auth@docker
-            - traefik.http.serversTransports.apitransport.insecureSkipVerify=true
     backend:
         profiles: ["prod"]
         image: ghcr.io/stipot-com/inimatic-backend:latest
@@ -102,6 +101,7 @@ services:
             - traefik.http.services.api.loadbalancer.server.port=3030
             - traefik.http.services.api.loadbalancer.server.scheme=https
             - traefik.http.services.api.loadbalancer.serversTransport=apitransport@docker
+            - traefik.http.serversTransports.apitransport.insecureSkipVerify=true
             # (остальные security/ratelimit метки — как были)
             - traefik.http.routers.api.middlewares=api-sec@docker,api-rl@docker
             - traefik.http.middlewares.api-sec.headers.stsSeconds=63072000

--- a/src/adaos/integrations/inimatic/package.json
+++ b/src/adaos/integrations/inimatic/package.json
@@ -28,7 +28,7 @@
 		"start": "ng serve --host 0.0.0.0",
 		"build": "ionic build",
 		"builddev": "ionic build",
-		"buildprod": "ionic build --prod",
+                "buildprod": "ionic build --configuration production",
 		"buildlocal": "npx ng run app:build.local",
 		"start:api-dev": "cross-env DOTENV_CONFIG_PATH=./backend/.env nodemon --exec node --no-warnings=ExperimentalWarning -r dotenv/config --loader ts-node/esm ./backend/app.ts",
 		"build:api": "tsc -p ./backend/tsconfig.backend.json",


### PR DESCRIPTION
## Summary
- ensure the Traefik serversTransport for the API service is declared with the backend container so the Docker provider can locate it at runtime
- keep the Traefik dashboard basic-auth label intact without line breaks while retaining existing security middleware configuration
- update the frontend production build script to use `ionic build --configuration production`, matching the modern Ionic CLI expectations used in CI/CD

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6e30b6a348332b34132142aedd7ac