### PR TITLE
Fix httpx cert usage for CLI requests

### DIFF
--- a/src/adaos/adapters/db/sqlite.py
+++ b/src/adaos/adapters/db/sqlite.py
@@ -7,8 +7,11 @@ add_or_update_entity, update_skill_version, list_entities, set_installed_flag.
 и ту же схему таблиц (skills/skill_versions, scenarios/scenario_versions).
 """
 from __future__ import annotations
+import time
 from typing import Optional, Iterable, Literal, List, Dict, Any
+
 from adaos.services.agent_context import get_ctx
+from adaos.services.id_gen import new_id
 
 Entity = Literal["skills", "scenarios"]
 
@@ -142,3 +145,202 @@ def list_versions(name: str) -> Optional[str]:
         cur = con.execute("SELECT active_version FROM skills WHERE name=?", (name,))
         row = cur.fetchone()
     return row[0] if row and row[0] else None
+
+
+def idem_get(key: str, method: str, path: str, principal_id: str, body_hash: str) -> dict | None:
+    if not key:
+        return None
+    sql = get_ctx().sql
+    now = int(time.time())
+    with sql.connect() as con:
+        cur = con.execute(
+            """
+            SELECT status_code, body_json, event_id, server_time_utc
+            FROM idempotency_cache
+            WHERE key=? AND method=? AND path=? AND principal_id=? AND body_hash=? AND expires_at>=?
+            """,
+            (key, method, path, principal_id, body_hash, now),
+        )
+        row = cur.fetchone()
+    if not row:
+        return None
+    return {
+        "status_code": row[0],
+        "body_json": row[1],
+        "event_id": row[2],
+        "server_time_utc": row[3],
+    }
+
+
+def idem_put(
+    key: str,
+    method: str,
+    path: str,
+    principal_id: str,
+    body_hash: str,
+    status_code: int,
+    body_json: str,
+    event_id: str,
+    server_time_utc: str,
+    *,
+    ttl: int = 600,
+) -> None:
+    if not key:
+        return
+    sql = get_ctx().sql
+    now = int(time.time())
+    expires_at = now + max(ttl, 1)
+    with sql.connect() as con:
+        con.execute(
+            """
+            INSERT OR REPLACE INTO idempotency_cache(
+                key, method, path, principal_id, body_hash,
+                status_code, body_json, event_id, server_time_utc,
+                created_at, expires_at
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                key,
+                method,
+                path,
+                principal_id,
+                body_hash,
+                status_code,
+                body_json,
+                event_id,
+                server_time_utc,
+                now,
+                expires_at,
+            ),
+        )
+        con.commit()
+
+
+def ca_load() -> dict:
+    sql = get_ctx().sql
+    with sql.connect() as con:
+        cur = con.execute("SELECT ca_key_pem, ca_cert_pem, next_serial FROM ca_state WHERE id=1")
+        row = cur.fetchone()
+        if row:
+            return {"ca_key_pem": row[0], "ca_cert_pem": row[1], "next_serial": int(row[2])}
+        from datetime import datetime, timedelta
+
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import NameOID
+
+        key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
+        subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "AdaOS Root CA")])
+        now = datetime.utcnow()
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(subject)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - timedelta(minutes=1))
+            .not_valid_after(now + timedelta(days=3650))
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        )
+        cert = builder.sign(private_key=key, algorithm=hashes.SHA256())
+        key_pem = key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode("utf-8")
+        cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
+        con.execute(
+            "INSERT INTO ca_state(id, ca_key_pem, ca_cert_pem, next_serial) VALUES(1, ?, ?, ?)",
+            (key_pem, cert_pem, 1),
+        )
+        con.commit()
+        return {"ca_key_pem": key_pem, "ca_cert_pem": cert_pem, "next_serial": 1}
+
+
+def ca_update_serial(next_serial: int) -> None:
+    sql = get_ctx().sql
+    with sql.connect() as con:
+        con.execute("UPDATE ca_state SET next_serial=? WHERE id=1", (int(next_serial),))
+        con.commit()
+
+
+def subnet_get_or_create(owner_id: str) -> dict:
+    sql = get_ctx().sql
+    now = int(time.time())
+    with sql.connect() as con:
+        cur = con.execute("SELECT subnet_id, owner_id, created_at FROM subnets WHERE owner_id=?", (owner_id,))
+        row = cur.fetchone()
+        if row:
+            return {"subnet_id": row[0], "owner_id": row[1], "created_at": row[2]}
+        subnet_id = new_id()
+        con.execute(
+            "INSERT INTO subnets(subnet_id, owner_id, created_at) VALUES(?, ?, ?)",
+            (subnet_id, owner_id, now),
+        )
+        con.commit()
+        return {"subnet_id": subnet_id, "owner_id": owner_id, "created_at": now}
+
+
+def device_get_by_fingerprint(subnet_id: str, fingerprint: str) -> dict | None:
+    sql = get_ctx().sql
+    with sql.connect() as con:
+        cur = con.execute(
+            """
+            SELECT device_id, subnet_id, role, fingerprint, cert_pem, issued_at, expires_at
+            FROM devices
+            WHERE subnet_id=? AND fingerprint=?
+            """,
+            (subnet_id, fingerprint),
+        )
+        row = cur.fetchone()
+    if not row:
+        return None
+    return {
+        "device_id": row[0],
+        "subnet_id": row[1],
+        "role": row[2],
+        "fingerprint": row[3],
+        "cert_pem": row[4],
+        "issued_at": int(row[5]),
+        "expires_at": int(row[6]),
+    }
+
+
+def device_upsert_hub(
+    subnet_id: str,
+    fingerprint: str,
+    cert_pem: str,
+    issued_at: int,
+    expires_at: int,
+) -> dict:
+    existing = device_get_by_fingerprint(subnet_id, fingerprint)
+    sql = get_ctx().sql
+    if existing:
+        with sql.connect() as con:
+            con.execute(
+                "UPDATE devices SET cert_pem=?, issued_at=?, expires_at=? WHERE device_id=?",
+                (cert_pem, issued_at, expires_at, existing["device_id"]),
+            )
+            con.commit()
+        existing.update({"cert_pem": cert_pem, "issued_at": issued_at, "expires_at": expires_at})
+        return existing
+    device_id = new_id()
+    with sql.connect() as con:
+        con.execute(
+            """
+            INSERT INTO devices(device_id, subnet_id, role, fingerprint, cert_pem, issued_at, expires_at)
+            VALUES(?, ?, 'hub', ?, ?, ?, ?)
+            """,
+            (device_id, subnet_id, fingerprint, cert_pem, issued_at, expires_at),
+        )
+        con.commit()
+    return {
+        "device_id": device_id,
+        "subnet_id": subnet_id,
+        "role": "hub",
+        "fingerprint": fingerprint,
+        "cert_pem": cert_pem,
+        "issued_at": issued_at,
+        "expires_at": expires_at,
+    }

--- a/src/adaos/adapters/db/sqlite_schema.py
+++ b/src/adaos/adapters/db/sqlite_schema.py
@@ -42,6 +42,55 @@ _SCHEMA = (
         created_at TIMESTAMP
     );
     """,
+    """
+    CREATE TABLE IF NOT EXISTS subnets (
+        subnet_id TEXT PRIMARY KEY,
+        owner_id TEXT,
+        created_at INT
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS devices (
+        device_id TEXT PRIMARY KEY,
+        subnet_id TEXT NOT NULL,
+        role TEXT NOT NULL,
+        fingerprint TEXT NOT NULL,
+        cert_pem TEXT NOT NULL,
+        issued_at INT NOT NULL,
+        expires_at INT NOT NULL,
+        UNIQUE(subnet_id, fingerprint)
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS idempotency_cache (
+        key TEXT,
+        method TEXT,
+        path TEXT,
+        principal_id TEXT,
+        body_hash TEXT,
+        status_code INT,
+        body_json TEXT,
+        event_id TEXT,
+        server_time_utc TEXT,
+        created_at INT,
+        expires_at INT,
+        PRIMARY KEY(key, method, path, principal_id, body_hash)
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS ca_state (
+        id INTEGER PRIMARY KEY CHECK(id=1),
+        ca_key_pem TEXT NOT NULL,
+        ca_cert_pem TEXT NOT NULL,
+        next_serial INTEGER NOT NULL
+    );
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_devices_fpr ON devices(fingerprint);
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_idem_exp ON idempotency_cache(expires_at);
+    """,
 )
 
 

--- a/src/adaos/apps/api/auth.py
+++ b/src/adaos/apps/api/auth.py
@@ -1,4 +1,7 @@
+import os
+
 from fastapi import Header, HTTPException, status
+
 from adaos.services.node_config import load_config
 
 
@@ -27,3 +30,9 @@ async def require_token(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or missing X-AdaOS-Token",
         )
+
+
+def require_owner_token(token: str) -> None:
+    expected = os.getenv("ADAOS_ROOT_OWNER_TOKEN") or ""
+    if not expected or token != expected:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid owner token")

--- a/src/adaos/apps/api/root_endpoints.py
+++ b/src/adaos/apps/api/root_endpoints.py
@@ -1,13 +1,27 @@
 from __future__ import annotations
-from fastapi import APIRouter, HTTPException
 import asyncio
+import json
+import hashlib
 import os
-from typing import Literal
-from pydantic import BaseModel, Field
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from fastapi import APIRouter, Header, HTTPException, Request, Response
+from pydantic import BaseModel, Field, ValidationError
+
 from openai import OpenAI
 from openai import OpenAIError
 
-router = APIRouter(prefix="/v1/root", tags=["root"])
+from adaos.adapters.db import sqlite as sqlite_db
+from adaos.apps.api.auth import require_owner_token
+from adaos.services.id_gen import new_id
+from adaos.services.root.service import RootAuthService
+
+router = APIRouter()
+root_router = APIRouter(prefix="/v1/root", tags=["root"])
+subnet_router = APIRouter(prefix="/v1/subnets", tags=["subnets"])
+router.include_router(root_router)
+router.include_router(subnet_router)
 
 
 class ChatMessage(BaseModel):
@@ -30,13 +44,13 @@ def _get_openai_client() -> OpenAI:
     return OpenAI(api_key=api_key)
 
 
-@router.post("/register")
+@root_router.post("/register")
 def root_register() -> dict:
     """Legacy bootstrap endpoint has been replaced by owner-based flow."""
     raise RuntimeError("legacy endpoint removed; use owner login flow")
 
 
-@router.post("/llm/chat")
+@root_router.post("/llm/chat")
 async def llm_chat(payload: ChatRequest) -> dict:
     client = _get_openai_client()
     request_payload: dict = {
@@ -59,3 +73,75 @@ async def llm_chat(payload: ChatRequest) -> dict:
         raise HTTPException(status_code=502, detail=f"OpenAI request failed: {exc}") from exc
 
     return completion.model_dump()
+
+
+class SubnetRegisterRequest(BaseModel):
+    csr_pem: str
+    fingerprint: str
+    owner_token: str
+    hints: dict[str, Any] | None = None
+
+
+def _canonical_body(data: dict[str, Any]) -> str:
+    return json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+@subnet_router.post("/register")
+async def subnet_register(
+    request: Request,
+    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+) -> Response:
+    payload_raw = await request.json()
+    if not isinstance(payload_raw, dict):
+        raise HTTPException(status_code=422, detail="Invalid request body")
+    try:
+        payload = SubnetRegisterRequest.model_validate(payload_raw)
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=exc.errors()) from exc
+
+    require_owner_token(payload.owner_token)
+    owner_id = RootAuthService.resolve_owner(payload.owner_token)
+    canonical_source = payload.model_dump(mode="python")
+    body_hash = hashlib.sha256(_canonical_body(canonical_source).encode("utf-8")).hexdigest()
+
+    if idempotency_key:
+        cached = sqlite_db.idem_get(idempotency_key, "POST", "/v1/subnets/register", owner_id, body_hash)
+        if cached:
+            return Response(content=cached["body_json"], status_code=cached["status_code"], media_type="application/json")
+
+    result = RootAuthService.register_subnet(payload.owner_token, payload.csr_pem, payload.fingerprint, hints=payload.hints)
+    response_body = json.dumps(result, ensure_ascii=False, separators=(",", ":"))
+    if idempotency_key:
+        sqlite_db.idem_put(
+            idempotency_key,
+            "POST",
+            "/v1/subnets/register",
+            owner_id,
+            body_hash,
+            200,
+            response_body,
+            result["event_id"],
+            result["server_time_utc"],
+        )
+    return Response(content=response_body, status_code=200, media_type="application/json")
+
+
+@subnet_router.get("/register/status")
+async def subnet_register_status(
+    fingerprint: str,
+    owner_token: str = Header(..., alias="X-Owner-Token"),
+) -> dict:
+    require_owner_token(owner_token)
+    owner_id = RootAuthService.resolve_owner(owner_token)
+    subnet = sqlite_db.subnet_get_or_create(owner_id)
+    device = sqlite_db.device_get_by_fingerprint(subnet["subnet_id"], fingerprint)
+    now_iso = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    if device:
+        data = {
+            "subnet_id": subnet["subnet_id"],
+            "hub_device_id": device["device_id"],
+            "cert_pem": device["cert_pem"],
+        }
+    else:
+        data = None
+    return {"data": data, "event_id": new_id(), "server_time_utc": now_iso}

--- a/src/adaos/services/id_gen.py
+++ b/src/adaos/services/id_gen.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+_RANDOM_BITS = 80
+_TIME_BITS = 48
+_MAX_RANDOM = (1 << _RANDOM_BITS) - 1
+_LOCK = threading.Lock()
+_last_timestamp = 0
+_last_random = 0
+
+
+def _encode_ulid(value: int) -> str:
+    chars: list[str] = []
+    for _ in range(26):
+        value, idx = divmod(value, 32)
+        chars.append(_ALPHABET[idx])
+    return "".join(reversed(chars))
+
+
+def new_id() -> str:
+    global _last_timestamp, _last_random
+    millis = int(time.time() * 1000)
+    with _LOCK:
+        if millis > _last_timestamp:
+            _last_timestamp = millis
+            _last_random = int.from_bytes(os.urandom(10), "big")
+        else:
+            millis = _last_timestamp
+            _last_random = (_last_random + 1) & _MAX_RANDOM
+            if _last_random == 0:
+                while millis <= _last_timestamp:
+                    time.sleep(0.001)
+                    millis = int(time.time() * 1000)
+                _last_timestamp = millis
+                _last_random = int.from_bytes(os.urandom(10), "big")
+        value = (_last_timestamp << _RANDOM_BITS) | _last_random
+    return _encode_ulid(value)
+
+
+__all__ = ["new_id"]


### PR DESCRIPTION
## Summary
- add owner-token auth guard, idempotent subnet registration endpoints, and CA-backed certificate issuance on the root API
- persist CA/keypairs, idempotency cache, and hub device records in SQLite with reusable monotonic IDs
- wire a new CLI `adaos dev hub-enroll` command plus frontend helpers for subnet registration and status queries, ensuring the CLI HTTP helper handles httpx certificate arguments correctly across versions

### Code-Map Proof
| File | Key updates |
| --- | --- |
| src/adaos/apps/api/root_endpoints.py | + POST /v1/subnets/register, + GET /v1/subnets/register/status |
| src/adaos/adapters/db/sqlite_schema.py | + subnets/devices/idempotency_cache/ca_state tables & indexes |
| src/adaos/adapters/db/sqlite.py | + idem_get/idem_put, ca_load/update_serial, subnet_get_or_create, device_upsert_hub |
| src/adaos/services/root/service.py | + RootAuthService.register_subnet + resolve_owner |
| src/adaos/apps/cli/commands/dev.py | + hub-enroll command (aliases hub_enroll, hub-register) |
| src/adaos/apps/cli/root_ops.py | + ensure_hub_keypair/build_csr/fingerprint helpers & HTTP wrappers |
| src/adaos/services/id_gen.py | + uuidv7-style monotonic new_id() |
| src/adaos/integrations/inimatic/src/app/core/adaos/adaos-client.service.ts | + subnetRegister/subnetRegisterStatus exports |
| src/adaos/apps/api/auth.py | + require_owner_token() guard |

Deviation Note: none

------
https://chatgpt.com/codex/tasks/task_e_68e2ee2d10448332896b9e7704e50896